### PR TITLE
Got the traceback error to go away

### DIFF
--- a/invalid-headings.py
+++ b/invalid-headings.py
@@ -1,17 +1,13 @@
-import re
 fname = raw_input('Enter file name: ')
 if len(fname) == 0:
     fname = 'invalid headings report.txt'
     
-with open(fname) as file, open("Invalid-Headings-Fixed.txt") as file2:
-#file = open(fname)
-#newopen = open("./Invalid-Headings-Fixed.txt", "w")
+with open(fname) as file, open("Invalid-Headings-Fixed.txt", "w") as file2:
     data=file.read().replace("\n ", " ")    
 
-for line in data:
-    line = line.rstrip()
-    if "k970" not in line:
-        f2.write(line.strip(),"\n")    
-    else:
-        continue
-print newopen
+    for line in data:
+        line = line.rstrip()
+        if "k970" not in line:
+            file2.write(line.strip() + "\n")    
+        else:
+            continue


### PR DESCRIPTION
You were close! The "w" is what tells a file to open for writing instead of reading.

If you run this you'll see that the output comes out one character per line, which is probably not what you intended. This is because the file.read() produces a string, so you're actually working character by character not line by line.

Try using "for data in file:" instead of "data=file.read(...) ... for line in data:". You'll still have to do the replace() call inside the loop since you're going line by line instead of first doing it over the entire string.
